### PR TITLE
Gender lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ erDiagram
         INTEGER imd_quartile_country
         STRING gender
         STRING age_group
-        STRING qualification_2020
+        STRING qualification
         STRING ethnicity
+        STRING government_office_region
     }
 
     question_responses {

--- a/README.md
+++ b/README.md
@@ -75,26 +75,22 @@ erDiagram
 
 #### Adding a new Wave
 1. Create a new row in `definitions/lookups/lookup_survey_waves.sqlx`.
-2. Execute the workflow so that the BigQuery table `survey_waves` generates an ID for that row.
-Query that table and copy the `survey_wave_id`.
-3. Query the `questions` table in BigQuery and identify all questions that are included in the wave.
-4. For each question,
-    add a new row in the `definitions/lookups/lookup_survey_wave_questions.sqlx` file including the `survey_wave_id` noted earlier and the `question_id`.
-5. Execute the workflow to ensure `survey_wave_questions` is populated as expected.
+2. For each question,
+    add a new row in the `definitions/lookups/lookup_survey_wave_questions.sqlx` file including the `wave_name` and `src_question_id`.
+3. Execute the workflow to ensure `survey_wave_questions` is populated as expected.
 
 #### Adding a new Question
 1. Create a new row in `definitions/lookups/lookup_questions.sqlx`.
-2. Execute the workflow to populate the `questions` table. Then query it and make a note of the `question_id`.
-3. Create a new row in `definitions/lookups/lookup_question_response_choices.sqlx` using the `question_id`.
+2. Create a new row in `definitions/lookups/lookup_question_response_choices.sqlx` using the corresponding `src_question_id`.
 You'll need to know the name of the column in the source data which contains the values along with the coded values and the associated selection text.
-4. Execute the workflow and inspect the output of the `question_response_choices` table in BigQuery.
-5. Add the column which contains the coded values to the `UNPIVOT` code in `definitions/staging/stg_unpack_question_responses.sqlx`.
+3. Execute the workflow and inspect the output of the `question_response_choices` table in BigQuery.
+4. Add the column which contains the coded values to the `UNPIVOT` code in `definitions/staging/stg_unpack_question_responses.sqlx`.
 
 ### Deployment
 Once you PR is reviewed and approved, merge into `main`.
 
 The production release configuration is based on `main` and will compile once a day. To manually compile, go to [Release Configurations](https://console.cloud.google.com/bigquery/dataform/locations/europe-west2/repositories/polling/details/release-scheduling?hl=en&inv=1&invt=Ab1Ofw&project=gds-bq-reporting).
-Then select the `production` configuration and `Start Execution`.
+Then select the `production` configuration and select `New compliation` which will sync to the latest changes on `main` branch. Then, go back to the "Releases & Scheduling" section and choose `Start Execution`.
 
 ## Licence
 

--- a/definitions/assertions/staging/assert_wave_12_count.sqlx
+++ b/definitions/assertions/staging/assert_wave_12_count.sqlx
@@ -8,4 +8,4 @@ SELECT
 FROM
   ${ref("stg_wave_12")}
 HAVING
-  actual_row_count != 619
+  actual_row_count != 1593

--- a/definitions/lookups/lookup_age_group.sqlx
+++ b/definitions/lookups/lookup_age_group.sqlx
@@ -1,14 +1,17 @@
 config {
   type: "table",
   assertions : {
-    uniqueKey: ["provider", "age_code"]
+    uniqueKey: ["provider", "age_code"],
+    rowConditions: [
+        "age_group IN ('18-24', '25-34', '35-44', '45-54', '55-64', '65-74', '75+')"
+    ]
   },
   columns: {
       provider: "The name of the organisation performing the polling (all lowercase).",
       age_code: "The coded value received in the data.",
       age_group: "The text which was presented the user when making a selection.",
     },
-  description: "A centralized lookup table to map provider-specific age codes to standardized age groups."
+  description: "A centralised lookup table to map provider-specific age codes to standardised age groups."
 }
 
 SELECT

--- a/definitions/lookups/lookup_ethnicity.sqlx
+++ b/definitions/lookups/lookup_ethnicity.sqlx
@@ -1,0 +1,43 @@
+config {
+  type: "table",
+  assertions : {
+    uniqueKey: ["provider", "ethnicity_code"],
+    rowConditions: [
+        `ethnicity IN ("English/Welsh/Scottish/Northern Irish/British", "Irish", "Gypsy or Irish Traveller", "Other White", "White and Black Caribbean", "White and Black African", "White and Asian", "Other Mixed / Multiple", "Indian", "Pakistani", "Bangladeshi", "Chinese", "Other Asian or Asian British", "Caribbean", "African", "Other Black or Black British", "Arab", "Any other", "Prefer not to say")`
+    ]
+  },
+  columns: {
+      provider: "The name of the organisation performing the polling (all lowercase).",
+      ethnicity_code: "The coded value received in the data.",
+      ethnicity_group: "The text which was presented the user when making a selection.",
+    },
+  description: "A centralised lookup table to map provider-specific ethnicity codes to human-readable values."
+}
+
+SELECT
+  *
+FROM
+  UNNEST(
+    ARRAY<STRUCT<provider STRING, ethnicity_code STRING, ethnicity STRING>>[
+      -- Rule set for provider 'bmg'
+      ('bmg', '1', 'English/Welsh/Scottish/Northern Irish/British'),
+      ('bmg', '2', 'Irish'),
+      ('bmg', '3', 'Gypsy or Irish Traveller'),
+      ('bmg', '4', 'Other White'),
+      ('bmg', '5', 'White and Black Caribbean'),
+      ('bmg', '6', 'White and Black African'),
+      ('bmg', '7', 'White and Asian'),
+      ('bmg', '8', 'Other Mixed / Multiple'),
+      ('bmg', '9', 'Indian'),
+      ('bmg', '10', 'Pakistani'),
+      ('bmg', '11', 'Bangladeshi'),
+      ('bmg', '12', 'Chinese'),
+      ('bmg', '13', 'Other Asian or Asian British'),
+      ('bmg', '14', 'Caribbean'),
+      ('bmg', '15', 'African'),
+      ('bmg', '16', 'Other Black or Black British'),
+      ('bmg', '17', 'Arab'),
+      ('bmg', '95', 'Any other'),
+      ('bmg', '98', 'Prefer not to say')
+    ]
+  )

--- a/definitions/lookups/lookup_gender.sqlx
+++ b/definitions/lookups/lookup_gender.sqlx
@@ -1,0 +1,28 @@
+config {
+  type: "table",
+  assertions : {
+    uniqueKey: ["provider", "gender_code"],
+    rowConditions: [
+        "gender IN ('A man (including trans man)', 'A woman (including trans woman)', 'Other', 'Prefer not to say')"
+    ]
+  },
+  columns: {
+      provider: "The name of the organisation performing the polling (all lowercase).",
+      age_code: "The coded value received in the data.",
+      age_group: "The text which was presented the user when making a selection.",
+    },
+  description: "A centralised lookup table to map provider-specific gender codes to human-readable values."
+}
+
+SELECT
+  *
+FROM
+  UNNEST(
+    ARRAY<STRUCT<provider STRING, gender_code STRING, gender STRING>>[
+      -- Rule set for provider 'bmg'
+      ('bmg', '1', 'A man (including trans man)'),
+      ('bmg', '2', 'A woman (including trans woman)'),
+      ('bmg', '95', 'Other'),
+      ('bmg', '98', 'Prefer not to say')
+    ]
+  )

--- a/definitions/lookups/lookup_government_office_region.sqlx
+++ b/definitions/lookups/lookup_government_office_region.sqlx
@@ -1,0 +1,36 @@
+config {
+  type: "table",
+  assertions : {
+    uniqueKey: ["provider", "government_office_region_code"],
+    rowConditions: [
+        "government_office_region IN ('East Midlands', 'East of England', 'London', 'North East', 'North West', 'South East', 'South West', 'West Midlands', 'Yorkshire and The Humber', 'Northern Ireland', 'Scotland', 'Wales')"
+    ]
+  },
+  columns: {
+      provider: "The name of the organisation performing the polling (all lowercase).",
+      government_office_region_code: "The coded value received in the data.",
+      government_office_region: "The text which was presented the user when making a selection.",
+    },
+  description: "A centralised lookup table to map provider-specific age codes to standardised age groups."
+}
+
+SELECT
+  *
+FROM
+  UNNEST(
+    ARRAY<STRUCT<provider STRING, government_office_region_code STRING, government_office_region STRING>>[
+      -- Rule set for provider 'bmg'
+      ('bmg', '1', 'East Midlands'),
+      ('bmg', '2', 'East of England'),
+      ('bmg', '3', 'London'),
+      ('bmg', '4', 'North East'),
+      ('bmg', '5', 'North West'),
+      ('bmg', '6', 'South East'),
+      ('bmg', '7', 'South West'),
+      ('bmg', '8', 'West Midlands'),
+      ('bmg', '9', 'Yorkshire and The Humber'),
+      ('bmg', '10', 'Northern Ireland'),
+      ('bmg', '11', 'Scotland'),
+      ('bmg', '12', 'Wales')
+    ]
+  )

--- a/definitions/lookups/lookup_qualification.sqlx
+++ b/definitions/lookups/lookup_qualification.sqlx
@@ -1,0 +1,33 @@
+config {
+  type: "table",
+  assertions : {
+    uniqueKey: ["provider", "qualification_code"],
+    rowConditions: [
+        "qualification IN ('No qualifications', 'Other qualification', 'Up to 4 GCSEs or equivalent (NVQ level 1)', '5 or more GCSEs or equivalent (NVQ level 2)', 'A levels or equivalent (Such as Scottish Highers or NVQ level 3)', 'Bachelors Degree or equivalent (such as HND or NVQ level 4)', 'Masters Degree or equivalent (NVQ level 5)', 'PHD', 'Prefer not to say')"
+    ]
+  },
+  columns: {
+      provider: "The name of the organisation performing the polling (all lowercase).",
+      age_code: "The coded value received in the data.",
+      age_group: "The text which was presented the user when making a selection.",
+    },
+  description: "A centralised lookup table to map provider-specific qualification codes to human-readable values."
+}
+
+SELECT
+  *
+FROM
+  UNNEST(
+    ARRAY<STRUCT<provider STRING, qualification_code STRING, qualification STRING>>[
+      -- Rule set for provider 'bmg'
+      ('bmg', '1', 'No qualifications'),
+      ('bmg', '2', 'Other qualification'),
+      ('bmg', '3', 'Up to 4 GCSEs or equivalent (NVQ level 1)'),
+      ('bmg', '4', '5 or more GCSEs or equivalent (NVQ level 2)'),
+      ('bmg', '5', 'A levels or equivalent (Such as Scottish Highers or NVQ level 3)'),
+      ('bmg', '6', 'Bachelors Degree or equivalent (such as HND or NVQ level 4)'),
+      ('bmg', '7', 'Masters Degree or equivalent (NVQ level 5)'),
+      ('bmg', '8', 'PHD'),
+      ('bmg', '9', 'Prefer not to say')
+    ]
+  )

--- a/definitions/lookups/lookup_survey_wave_questions.sqlx
+++ b/definitions/lookups/lookup_survey_wave_questions.sqlx
@@ -38,7 +38,6 @@ FROM
     ('wave 13', 'ql1b_18'),
     ('wave 13', 'ql1b_19'),
     ('wave 13', 'ql1b_20'),
-    ('wave 13', 'ql1b_20'),
     ('wave 13', 'ql1c_3'),
     ('wave 13', 'ql1c_4'),
     ('wave 13', 'ql1c_5'),

--- a/definitions/staging/stg_bmg_all_waves.sqlx
+++ b/definitions/staging/stg_bmg_all_waves.sqlx
@@ -4,7 +4,10 @@ config {
         uniqueKey: ["survey_response_id"],
         nonNull: ["survey_response_id", "survey_wave_id"],
         rowConditions: [
-            "age_code IN ('2', '3', '4', '5', '6', '7', '8')"
+            "age_code IN ('1', '2', '3', '4', '5', '6', '7', '8')",
+            "gender_code IN ('1', '2', '95', '98')",
+            "ethnicity_code IN ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '95', '98')",
+            "qualification_code IN ('1', '2', '3', '4', '5', '6', '7', '8', '9')"
         ]
     },
 }
@@ -66,11 +69,11 @@ SELECT
   TRIM(CAST(responseid AS STRING)) AS src_response_id,
   CAST(WEIGHT AS FLOAT64) AS weight,
   CAST(quartile_country AS INTEGER) AS imd_quartile_country,
-  TRIM(CAST(gender AS STRING)) AS gender,
+  NULLIF(TRIM(CAST(gender AS STRING)), '') AS gender_code,
   NULLIF(TRIM(CAST(age AS STRING)), '') AS age_code,
-  TRIM(CAST(qualification2020 AS STRING)) AS qualification_2020,
+  NULLIF(TRIM(CAST(qualification2020 AS STRING)), '') AS qualification_code,
   TRIM(CAST(gor_code AS STRING)) AS gor_code,
-  TRIM(CAST(ethnicity AS STRING)) AS ethnicity,
+  NULLIF(TRIM(CAST(ethnicity AS STRING)), '') AS ethnicity_code,
   -- single answer questions
   NULLIF(TRIM(CAST(ql5 AS STRING)), '') AS ql5,
   NULLIF(TRIM(CAST(ql7 AS STRING)), '') AS ql7,
@@ -95,11 +98,11 @@ SELECT
   src_response_id,
   weight,
   imd_quartile_country,
-  gender,
+  gender_code,
   age_code,
-  qualification_2020,
+  qualification_code,
   gor_code,
-  ethnicity,
+  ethnicity_code,
   -- single answer questions
   ql5,
   ql7,

--- a/definitions/staging/stg_bmg_all_waves.sqlx
+++ b/definitions/staging/stg_bmg_all_waves.sqlx
@@ -7,7 +7,8 @@ config {
             "age_code IN ('1', '2', '3', '4', '5', '6', '7', '8')",
             "gender_code IN ('1', '2', '95', '98')",
             "ethnicity_code IN ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '95', '98')",
-            "qualification_code IN ('1', '2', '3', '4', '5', '6', '7', '8', '9')"
+            "qualification_code IN ('1', '2', '3', '4', '5', '6', '7', '8', '9')",
+            "government_office_region_code IN ('1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12')"
         ]
     },
 }
@@ -72,7 +73,7 @@ SELECT
   NULLIF(TRIM(CAST(gender AS STRING)), '') AS gender_code,
   NULLIF(TRIM(CAST(age AS STRING)), '') AS age_code,
   NULLIF(TRIM(CAST(qualification2020 AS STRING)), '') AS qualification_code,
-  TRIM(CAST(gor_code AS STRING)) AS gor_code,
+  NULLIF(TRIM(CAST(gor_code AS STRING)), '') AS government_office_region_code,
   NULLIF(TRIM(CAST(ethnicity AS STRING)), '') AS ethnicity_code,
   -- single answer questions
   NULLIF(TRIM(CAST(ql5 AS STRING)), '') AS ql5,
@@ -101,7 +102,7 @@ SELECT
   gender_code,
   age_code,
   qualification_code,
-  gor_code,
+  government_office_region_code,
   ethnicity_code,
   -- single answer questions
   ql5,

--- a/definitions/survey_responses.sqlx
+++ b/definitions/survey_responses.sqlx
@@ -18,7 +18,8 @@ SELECT
   lookup_gender.gender,
   lookup_age_group.age_group,
   lookup_qualification.qualification,
-  lookup_ethnicity.ethnicity
+  lookup_ethnicity.ethnicity,
+  lookup_government_office_region.government_office_region
 FROM
   ${ref("stg_bmg_all_waves")} src
 LEFT JOIN
@@ -40,3 +41,7 @@ LEFT JOIN
   ${ref("lookup_qualification")} lookup_qualification
 USING
   (provider, qualification_code)
+LEFT JOIN
+  ${ref("lookup_government_office_region")} lookup_government_office_region
+USING
+  (provider, government_office_region_code)

--- a/definitions/survey_responses.sqlx
+++ b/definitions/survey_responses.sqlx
@@ -15,10 +15,10 @@ SELECT
   src.date,
   src.weight,
   src.imd_quartile_country,
-  src.gender,
+  lookup_gender.gender,
   lookup_age_group.age_group,
-  src.qualification_2020,
-  src.ethnicity
+  lookup_qualification.qualification,
+  lookup_ethnicity.ethnicity
 FROM
   ${ref("stg_bmg_all_waves")} src
 LEFT JOIN
@@ -28,4 +28,15 @@ LEFT JOIN
   ${ref("lookup_age_group")} lookup_age_group
 USING
     (provider, age_code)
-
+LEFT JOIN
+  ${ref("lookup_gender")} lookup_gender
+USING
+  (provider, gender_code)
+LEFT JOIN
+  ${ref("lookup_ethnicity")} lookup_ethnicity
+USING
+  (provider, ethnicity_code)
+LEFT JOIN
+  ${ref("lookup_qualification")} lookup_qualification
+USING
+  (provider, qualification_code)


### PR DESCRIPTION
Add remaining `survey_responses` lookups. I haven't added language yet as I'm not sure how it's used and how it appears in the source. If we do load the actual CSV for wave 13 data as @oliverroberts1-gds suggested then that would be a good time to check how that column works.