### PR TITLE
Bugfix: Suffix failing on merge to main

### DIFF
--- a/definitions/assertions/staging/assert_wave_contains_columns.sqlx
+++ b/definitions/assertions/staging/assert_wave_contains_columns.sqlx
@@ -29,14 +29,10 @@ WITH expected_column_names AS (
 -- This CTE gets the actual columns from the workspace dataset
 actual_column_names AS (
     SELECT
-        column_name
+        DISTINCT(column_name)
     FROM 
-        -- this has to be the origin govuk-polling.govuk_polling_response, not the project default "gds-bq-reporting"
-           `${dataform.projectConfig.defaultDatabase}.${dataform.projectConfig.defaultSchema}_${dataform.projectConfig.schemaSuffix}.INFORMATION_SCHEMA.COLUMNS`
-        /** `${dataform.projectConfig.defaultDatabase}.${dataform.projectConfig.defaultSchema}_${dataform.projectConfig.SUFFIX}.INFORMATION_SCHEMA.COLUMNS` **/
-    WHERE 
-        table_name = "src_bmg_all_waves"
-
+        -- this is our table of column_names
+           ${ref("src_column_names")}
 ),
 
 -- Find columns in the expected list that are missing from the actual table

--- a/definitions/config/query_actual_column_names.sqlx
+++ b/definitions/config/query_actual_column_names.sqlx
@@ -12,8 +12,5 @@ FROM (
         column_name
     FROM
     -- Ensure this remains pointing at the workspace dataset
-        `${dataform.projectConfig.defaultDatabase}.${dataform.projectConfig.defaultSchema}_${dataform.projectConfig.schemaSuffix}.INFORMATION_SCHEMA.COLUMNS`
-    WHERE
-
-        table_name = "src_bmg_all_waves"
+        ${ref("src_column_names")}
 )

--- a/definitions/config/retrieve_columns_from_base.sqlx
+++ b/definitions/config/retrieve_columns_from_base.sqlx
@@ -14,11 +14,7 @@ WITH table_columns AS (
     -- Extract numeric wave for sorting
     SAFE_CAST(REGEXP_EXTRACT(table_name, r'src_bmg_wave_(\d+)') AS INT64) AS wave_number
 
-  FROM `${dataform.projectConfig.defaultDatabase}.${dataform.projectConfig.defaultSchema}_${dataform.projectConfig.schemaSuffix}.INFORMATION_SCHEMA.COLUMNS`
-
-  WHERE 
-    -- Filter for tables that match the src_bmg_wave_ pattern
-    table_name LIKE 'src_bmg_wave_%'
+  FROM ${ref("src_column_names")}
 ),
 
 -- Create individual tuple strings for each column

--- a/definitions/sources/src_column_names.sqlx
+++ b/definitions/sources/src_column_names.sqlx
@@ -1,0 +1,9 @@
+config {type:"view"}
+
+SELECT 
+    table_name,
+    table_catalog,
+    column_name
+FROM
+ `govuk-polling.govuk_polling_responses.INFORMATION_SCHEMA.COLUMNS`
+ WHERE table_name LIKE "src_bmg_%"


### PR DESCRIPTION
Removed all use of dataform.projectConfig.Suffix as this breaks when we move to main as it returns an empty string.

- Fix: To instead create a view of INFORMATION_SCHEMA from our source dataset, which we then refer to within our queries as a substitute. 

This is then referred as a view 