### PR TITLE
Adding running with new wave 13

### DIFF
--- a/definitions/assertions/staging/assert_wave_13_count.sqlx
+++ b/definitions/assertions/staging/assert_wave_13_count.sqlx
@@ -11,4 +11,4 @@ FROM
   ${ref("src_bmg_all_waves")}
 WHERE wave_name = 'wave 13'
 HAVING
-  actual_row_count != 1568
+  actual_row_count != 1570

--- a/definitions/lookups/lookup_survey_wave_questions.sqlx
+++ b/definitions/lookups/lookup_survey_wave_questions.sqlx
@@ -152,6 +152,8 @@ FROM
     ('wave 13', 'ql7a_4'),
     ('wave 13', 'ql7a_5'),
     ('wave 13', 'ql7a_6'),
+    ('wave 13', 'ql7a_7'),
+    ('wave 13', 'ql7a_8'),
     ('wave 13', 'ql8a'),
     ('wave 13', 'ql12'),
     ('wave 13', 'ql13_1'),


### PR DESCRIPTION
1) Check_missing_survey_wave_questions correctly identified     ('wave 13', 'ql7a_8') and     ('wave 13', 'ql7a_7') were missing from questinos
2) Also updated actual row count, which has increased by 2 from 1568 to 1570