### PR TITLE
add additional freetext columns to exlusion list in upload script

### DIFF
--- a/scripts/bmg_polling_data_processor.py
+++ b/scripts/bmg_polling_data_processor.py
@@ -59,7 +59,7 @@ DATASET_ID = "govuk_polling_responses"
 GCP_LOCATION = "EU"
 
 # Text columns to clear (sensitive data)
-TEXT_COLUMNS = ["ql6", "ql10mar24", "ql11"]
+TEXT_COLUMNS = ["ql6", "ql10mar24", "ql11", "ql8", "ql9", "ql10", "ql10mar", "ql4a_95_other", "ql13mar"]
 
 # Wave numbers to process
 WAVES = [4, 5, 6, 7, 8, 9, 10, 11,12,13,14]


### PR DESCRIPTION
Adding the remaining freetext columns that need to be excluded on upload.

I have manually nulled in BigQuery those that were missed since the last upload.