### PR TITLE
IA-1566: output end-user tables to gds-bq-data project

### DIFF
--- a/definitions/question_response_choices.sqlx
+++ b/definitions/question_response_choices.sqlx
@@ -1,6 +1,6 @@
 config {
     type: "table",
-    database: "govuk-polling",
+    database: "gds-bq-data",
     schema: "govuk_polling_responses",
     assertions: {
         uniqueKey: ["question_response_choice_id"],

--- a/definitions/question_response_selections.sqlx
+++ b/definitions/question_response_selections.sqlx
@@ -1,6 +1,6 @@
 config {
     type: "table",
-    database: "govuk-polling",
+    database: "gds-bq-data",
     schema: "govuk_polling_responses",
     assertions: {
         uniqueKey: ["question_response_selection_id"],

--- a/definitions/question_responses.sqlx
+++ b/definitions/question_responses.sqlx
@@ -1,6 +1,6 @@
 config {
     type: "table",
-    database: "govuk-polling",
+    database: "gds-bq-data",
     schema: "govuk_polling_responses",
     assertions: {
         uniqueKey: ["question_response_id"],

--- a/definitions/questions.sqlx
+++ b/definitions/questions.sqlx
@@ -1,6 +1,6 @@
 config {
     type: "table",
-    database: "govuk-polling",
+    database: "gds-bq-data",
     schema: "govuk_polling_responses",
     assertions: {
         uniqueKey: ["question_id"],

--- a/definitions/survey_responses.sqlx
+++ b/definitions/survey_responses.sqlx
@@ -6,7 +6,7 @@ Excluded from nonNull Assertions:
 **/
 config {
     type: "table",
-    database: "govuk-polling",
+    database: "gds-bq-data",
     schema: "govuk_polling_responses",
     assertions: {
         uniqueKey: ["survey_response_id"],

--- a/definitions/survey_wave_questions.sqlx
+++ b/definitions/survey_wave_questions.sqlx
@@ -1,6 +1,6 @@
 config {
     type: "table",
-    database: "govuk-polling",
+    database: "gds-bq-data",
     schema: "govuk_polling_responses",
     columns: {
       survey_wave_question_id: "Unique identifier for a specific question within a specific wave.",

--- a/definitions/survey_waves.sqlx
+++ b/definitions/survey_waves.sqlx
@@ -1,6 +1,6 @@
 config {
     type: "table",
-    database: "govuk-polling",
+    database: "gds-bq-data",
     schema: "govuk_polling_responses",
     assertions: {
         uniqueKey: ["survey_wave_id"],


### PR DESCRIPTION
See [JIRA](https://gov-uk.atlassian.net/browse/IA-1566) for more details. The service account already had  the required permissions. I have made @oliverroberts1-gds aware as this change is relevant to [IA-1753](https://gov-uk.atlassian.net/browse/IA-1753).

[IA-1753]: https://gov-uk.atlassian.net/browse/IA-1753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[Successful run](https://console.cloud.google.com/bigquery/dataform/locations/europe-west2/repositories/polling/workspaces/IA-1566-change-output-dataset/workflows/1763390101-5c4b0a5c-dd3b-485d-9d5f-4b283802888f?project=gds-bq-reporting)